### PR TITLE
chore: rename agrilogy-landing-page → agri-landing-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "agrilogy-landing",
+  "name": "agri-landing",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agrilogy-landing",
+      "name": "agri-landing",
       "version": "0.1.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agrilogy-landing",
+  "name": "agri-landing",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Closes #4. Part of AgriLogy/agrilogy-back#48 (tracker).

## Changes
- package.json: `name: "agri-landing"` (short form, matches existing convention)
- package-lock.json refreshed

## Operator steps (after merge)
```bash
gh repo rename agri-landing-page -R AgriLogy/agrilogy-landing-page
cd ~/agrilogy && mv agrilogy-landing-page agri-landing-page
cd agri-landing-page && git remote set-url origin git@github.com:AgriLogy/agri-landing-page.git
```