### PR TITLE
chore(ci): auto-assign new issues and PRs to mks-zakaria

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,21 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Auto-assign issue
+        uses: pozil/auto-assign-issue@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: mks-zakaria
+          numOfAssignee: 1


### PR DESCRIPTION
Closes #9

Add the `pozil/auto-assign-issue` GitHub Actions workflow so every newly opened issue and PR is auto-assigned to mks-zakaria, enforcing the PR/issue assignment convention. Rolled out from agri-api.