### PR TITLE
ci: fix Auto Assign workflow failing on pull_request events

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,9 +13,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Auto-assign issue
-        uses: pozil/auto-assign-issue@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: mks-zakaria
-          numOfAssignee: 1
+      # A PR shares its repo's issue-number space, so the issues/assignees
+      # endpoint assigns both issues and PRs with one call. Pick whichever
+      # number the triggering event carries.
+      - name: Assign to mks-zakaria
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: gh api --method POST "repos/$REPO/issues/$NUMBER/assignees" -f "assignees[]=mks-zakaria"


### PR DESCRIPTION
Closes #11

Replaces the broken `pozil/auto-assign-issue@v1` step with a single `gh api` call to the `issues/{number}/assignees` endpoint (assigns both issues and PRs). Part of the org-wide rollout.